### PR TITLE
Feat/show articles: 記事詳細画面を実装しました

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,10 @@ gem "turbo-rails"
 gem "stimulus-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
+# Use sass
+gem "dartsass-rails", "~> 0.5.1"
+# Use faker
+gem 'faker'
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"
@@ -62,4 +66,3 @@ group :test do
   gem "selenium-webdriver"
 end
 
-gem "dartsass-rails", "~> 0.5.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,8 @@ GEM
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
+    faker (3.5.1)
+      i18n (>= 1.8.11, < 2)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -377,6 +379,7 @@ DEPENDENCIES
   capybara
   dartsass-rails (~> 0.5.1)
   debug
+  faker
   importmap-rails
   jbuilder
   kamal

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,6 +29,11 @@ body {
   color: $text-base-color;
 }
 
+a {
+  text-decoration: none;
+  color: $text-base-color;
+}
+
 .container {
   padding: 16px 16px;
   width: 100%;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,6 +3,7 @@
 @import 'tabs';
 @import 'variables';
 @import 'card';
+@import 'article';
 
 html {
   word-spacing: 1px;

--- a/app/assets/stylesheets/article.scss
+++ b/app/assets/stylesheets/article.scss
@@ -1,0 +1,43 @@
+$heart-size: 32px;
+$avatar-size: 32px;
+
+.article {
+  background-color: white;
+  margin: 16px 16px;
+  padding: 16px 16px;
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.25);
+  position: relative;
+
+  &_title {
+    font-size: 22px;
+  }
+
+  &_detail {
+    padding-top: 10px;
+    cursor: pointer;
+    display: flex;
+    font-size: 12px;
+
+    img {
+      width: $avatar-size;
+      height: $avatar-size;
+      border-radius: 100%;
+      margin-right: 16px;
+    }
+  }
+
+  &_content {
+    padding: 24px 0 32px;
+  }
+
+  &_heart {
+    position: absolute;
+    right: 16px;
+    bottom: 16px;
+
+    img {
+      width: $heart-size;
+      height: $heart-size;
+    }
+  }
+}

--- a/app/assets/stylesheets/card.scss
+++ b/app/assets/stylesheets/card.scss
@@ -9,6 +9,11 @@ $avatar-size: 32px;
   cursor: pointer;
   box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.25);
 
+  &_title {
+    font-size: 22px;
+    margin-bottom: 8px;
+  }
+
   &_heart {
     display: flex;
 

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -2,5 +2,9 @@ class ArticlesController < ApplicationController
   def index
     @articles = Article.all
   end
+
+  def show
+    @article = Article.find(params[:id])
+  end
 end
 

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,6 +1,6 @@
 class ArticlesController < ApplicationController
   def index
-    @article = Article.first
+    @articles = Article.all
   end
 end
 

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -10,27 +10,29 @@
   </div>
 
   <% @articles.each do |article| %>
-    <div class="card">
-      <div class="card_image">
-        <%= image_tag 'eyecatch1.png' %>
-      </div>
-      <div class="card_content">
-        <div class="card_title">
-          <%= article.title %>
+    <%= link_to article_path(article) do %>
+      <div class="card">
+        <div class="card_image">
+          <%= image_tag 'eyecatch1.png' %>
         </div>
-        <div class="card_heart">
-          <%= image_tag 'heart.svg' %>
-          <span>23</span>
-        </div>
-        <div class="card_detail">
-          <%= image_tag 'default-avatar.png' %>
-          <div>
-            <p>cohki0305</p>
-            <p>2020/4/16</p>
+        <div class="card_content">
+          <div class="card_title">
+            <%= article.title %>
+          </div>
+          <div class="card_heart">
+            <%= image_tag 'heart.svg' %>
+            <span>23</span>
+          </div>
+          <div class="card_detail">
+            <%= image_tag 'default-avatar.png' %>
+            <div>
+              <p>cohki0305</p>
+              <p>2020/4/16</p>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    <% end %>
   <% end %>
 
 </div>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -9,60 +9,28 @@
     </div>
   </div>
 
-  <div class="card">
-    <div class="card_image">
-      <%= image_tag 'eyecatch1.png' %>
-    </div>
-    <div class="card_content">
-      <div class="card_heart">
-        <%= image_tag 'heart.svg' %>
-        <span>23</span>
+  <% @articles.each do |article| %>
+    <div class="card">
+      <div class="card_image">
+        <%= image_tag 'eyecatch1.png' %>
       </div>
-      <div class="card_detail">
-        <%= image_tag 'default-avatar.png' %>
-        <div>
-          <p>cohki0305</p>
-          <p>2020/4/16</p>
+      <div class="card_content">
+        <div class="card_title">
+          <%= article.title %>
+        </div>
+        <div class="card_heart">
+          <%= image_tag 'heart.svg' %>
+          <span>23</span>
+        </div>
+        <div class="card_detail">
+          <%= image_tag 'default-avatar.png' %>
+          <div>
+            <p>cohki0305</p>
+            <p>2020/4/16</p>
+          </div>
         </div>
       </div>
     </div>
-  </div>
+  <% end %>
 
-  <div class="card">
-    <div class="card_image">
-      <%= image_tag 'eyecatch2.png' %>
-    </div>
-    <div class="card_content">
-      <div class="card_heart">
-        <%= image_tag 'heart.svg' %>
-        <span>23</span>
-      </div>
-      <div class="card_detail">
-        <%= image_tag 'default-avatar.png' %>
-        <div>
-          <p>cohki0305</p>
-          <p>2020/4/16</p>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="card">
-    <div class="card_image">
-      <%= image_tag 'eyecatch2.png' %>
-    </div>
-    <div class="card_content">
-      <div class="card_heart">
-        <%= image_tag 'heart.svg' %>
-        <span>23</span>
-      </div>
-      <div class="card_detail">
-        <%= image_tag 'default-avatar.png' %>
-        <div>
-          <p>cohki0305</p>
-          <p>2020/4/16</p>
-        </div>
-      </div>
-    </div>
-  </div>
 </div>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,0 +1,16 @@
+<div class="article">
+  <h1 class="article_title"><%= @article.title %></h1>
+  <div class="article_detail">
+    <%= image_tag 'default-avatar.png' %>
+    <div>
+      <p>cohki0305</p>
+      <p>2020/4/16</p>
+    </div>
+  </div>
+  <div class="article_content">
+    <%= @article.content %>
+  </div>
+  <div class="article_heart">
+    <%= image_tag 'heart.svg' %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   root to: 'articles#index'
+  resources :articles, only: [:show]
 
-  # Defines the root path route ("/")
-  # root "posts#index"
+
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,5 +8,9 @@
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
 
-Article.create({title: '素晴らしい記事', content: 'とても素晴らしい記事です。これは、本当にすごいです'})
-Article.create({title: 'よい記事', content: 'とてもよい記事です。これは、本当にすごいです'})
+10.times do
+  Article.create({
+    title: Faker::Lorem.sentence(word_count: 5),
+    content: Faker::Lorem.sentence(word_count: 100)
+  })
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,6 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+Article.create({title: '素晴らしい記事', content: 'とても素晴らしい記事です。これは、本当にすごいです'})
+Article.create({title: 'よい記事', content: 'とてもよい記事です。これは、本当にすごいです'})


### PR DESCRIPTION
## 変更の概要
- 記事詳細画面を実装しました 
  - ArticleModelから任意のインスタンスを取得し、画面に返しています
  - 記事一覧ページに詳細画面へのリンクを設置しました
  - ダミーデータ作成用にFakerをインストールし、seedからデータを流し込みました

## なぜこの変更をするのか
- CRUDの練習のため
- 一覧ページに本文を記述するとユーザビリティが悪いため、詳細ページとして切り出しています

## 変更内容
![image](https://github.com/user-attachments/assets/b9dd841a-6cc7-4536-9a2f-0778bc6f5d7a)

## 影響範囲
- ユーザーに影響すること
  - 詳細画面が閲覧可能になりました

- メンバーに影響すること
  - Fakerの仕様が可能になりました

## 備考
Fakerの使用方法については以下を参照ください
[Faker公式](https://github.com/faker-ruby/faker/tree/main)