### PR TITLE
feat: 記事の削除機能を実装しました

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -38,6 +38,13 @@ class ArticlesController < ApplicationController
 
   end
 
+  def destroy
+    article = Article.find(params[:id])
+    article.destroy!
+    flash[:notice] = '削除しました'
+    redirect_to root_path, status: :see_other
+  end
+
 
   private
   def article_params

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -11,6 +11,7 @@
         <%= image_tag 'actions.svg', class: 'dropbtn' %>
         <div class="dropdown-content mini">
           <%= link_to '編集する', edit_article_path(@article) %>
+          <%= link_to '削除する', article_path(@article), data:{ turbo_method: :delete, turbo_confirm: "削除してもよろしいですか？" } %>
         </div>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   root to: 'articles#index'
-  resources :articles, only: [:show, :new, :create, :edit, :update]
+  resources :articles, only: [:show, :new, :create, :edit, :update, :destroy]
 
 
 end


### PR DESCRIPTION
## 変更の概要
- 記事の削除機能を実装しました
  - 削除用のリンクを記事詳細のドロップダウンボタンに設置しました
  - 確認用ダイアログが表示できるようにしています

## なぜこの変更をするのか
CRUD実装のため

## 影響範囲
- メンバーに影響すること
  - 物理削除として実装しました
  - 大きな問題にはならないと考えていますが、削除しないほうがよいデータの場合注意してください

## どうやるのか
- 記事一覧画面（ルートページ）から記事詳細ページへ遷移
- 記事詳細ページの...をホバー
- 削除するボタンを押下
- ダイアログが表示されるので、OKを押下
- 削除実行


## 備考
- Turboを使用する場合の注意点については以下の記事を参考にしました
[Rails 7.0 + Ruby 3.1でゼロからアプリを作ってみたときにハマったところあれこれ](https://qiita.com/jnchito/items/5c41a7031404c313da1f#destroy%E3%81%AE%E3%83%AC%E3%82%B9%E3%83%9D%E3%83%B3%E3%82%B9%E3%81%AB-status-see_other-%E3%82%92%E4%BB%98%E3%81%91%E3%82%8B%E5%BF%85%E8%A6%81%E3%81%8C%E3%81%82%E3%82%8B)
