### PR TITLE
feat: articleモデルにバリデーションを追加しました

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -11,9 +11,22 @@
 
 class Article < ApplicationRecord
   validates :title, presence: true
+  validates :title, length: { minimum: 2, maximum: 100 }
+  validates :title, format: { with: /\A(?!@).*/ }
+
   validates :content, presence: true
+  validates :content, length: { minimum: 10 }
+  validates :content, uniqueness: true
+  validate :minimum_length_title_and_content
 
   def display_created_at
     I18n.l self.created_at, format: :short
+  end
+
+  private
+  def minimum_length_title_and_content
+    char_length = self.title.length + self.content.length
+    minimum_length = 50
+    errors.add(:content, "100文字以上の入力が必要です") if char_length <= minimum_length
   end
 end


### PR DESCRIPTION
## 変更の概要
- articleモデルに以下のバリデーションを追加しました
  - title
    - Non Null
    - 最低2文字、最高100文字
    - @から始まるタイトルを不許可
  - content
    - Non Null
    - 最低10文字
    - ユニーク制約
    - タイトルと本文合わせて50文字を超えること

- articleモデルのプロパティ
```
#  id         :integer          not null, primary key
#  title      :string
#  content    :text
#  created_at :datetime         not null
#  updated_at :datetime         not null
```

## なぜこの変更をするのか
- タイトルと本文の投稿時・編集時に適切なバリデーションを行うため

## テスト（手動）
- 概要に記述したバリデーションエラーの発生
- 概要に記述したバリデーションをクリアするデータのINSERT

## 影響範囲
- ユーザーに影響すること
- メンバーに影響すること
  - Articleの作成・編集時にバリデーションがかかるようになります
  - タイトルと本文合わせて50文字を超えること　という制約はカスタムバリデーションです
    - `minimum_length_title_and_content`メソッド内の`minimum_length`変数で最低文字数を定義しています
