### PR TITLE
Feat/follow: フォロー機能を実装しました

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,0 +1,10 @@
+class AccountsController < ApplicationController
+
+  def show
+    if User.find(params[:id]) == current_user
+      redirect_to profile_path
+    else
+      @user = User.find(params[:id])
+    end
+  end
+end

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,5 +1,4 @@
 class AccountsController < ApplicationController
-
   def show
     if User.find(params[:id]) == current_user
       redirect_to profile_path

--- a/app/controllers/followings_controller.rb
+++ b/app/controllers/followings_controller.rb
@@ -14,5 +14,4 @@ class FollowingsController < ApplicationController
     flash[:notice] = "フォローを解除しました"
     redirect_to account_path(user)
   end
-
 end

--- a/app/controllers/followings_controller.rb
+++ b/app/controllers/followings_controller.rb
@@ -1,0 +1,12 @@
+class FollowingsController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    debugger
+    user = User.find(params[:user_id])
+    current_user.follow!(user)
+    flash[:notice] = "フォローしました"
+    redirect_to account_path(user)
+  end
+
+end

--- a/app/controllers/followings_controller.rb
+++ b/app/controllers/followings_controller.rb
@@ -2,10 +2,16 @@ class FollowingsController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    debugger
-    user = User.find(params[:user_id])
+    user = User.find(params[:account_id])
     current_user.follow!(user)
     flash[:notice] = "フォローしました"
+    redirect_to account_path(user)
+  end
+
+  def destroy
+    user = User.find(params[:account_id])
+    current_user.unfollow!(user)
+    flash[:notice] = "フォローを解除しました"
     redirect_to account_path(user)
   end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -33,8 +33,4 @@ class Profile < ApplicationRecord
 
     "#{age}歳"
   end
-
-  def display_gender
-    self.gender || "unknown"
-  end
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: relationships
+#
+#  id           :bigint           not null, primary key
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  follower_id  :bigint           not null
+#  following_id :bigint           not null
+#
+# Indexes
+#
+#  index_relationships_on_follower_id   (follower_id)
+#  index_relationships_on_following_id  (following_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (follower_id => users.id)
+#  fk_rails_...  (following_id => users.id)
+#
+class Relationship < ApplicationRecord
+  belongs_to :follower, class_name: "User"
+  belongs_to :following, class_name: "User"
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,11 @@ class User < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :favorite_articles, through: :likes, source: :article
 
+  has_many :following_relationships, foreign_key: "follower_id", class_name: "Relationship", dependent: :destroy
+  has_many :followings, through: :following_relationships, source: :following
+  has_many :follower_relationships, foreign_key: "following_id", class_name: "Relationship", dependent: :destroy
+  has_many :followers, through: :follower_relationships, source: :follower
+
   delegate :display_gender, :display_age, to: :profile, allow_nil: true
 
   def has_written?(article)
@@ -39,6 +44,15 @@ class User < ApplicationRecord
 
   def display_name
     self.profile&.nickname || self.email.split("@").first
+  end
+
+  def follow!(user)
+    self.following_relationships.create!(following_id: user.id)
+  end
+
+  def unfollow!(user)
+    relationship = self.following_relationships.find_by!(following_id: user.id)
+    relationship.destroy!
   end
 
   def prepare_profile

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,6 +50,9 @@ class User < ApplicationRecord
     self.profile&.gender || "unknown"
   end
 
+  def has_followed?(user)
+    self.followings.exists?(user.id)
+  end
 
   def follow!(user)
     self.following_relationships.create!(following_id: user.id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,7 +32,7 @@ class User < ApplicationRecord
   has_many :follower_relationships, foreign_key: "following_id", class_name: "Relationship", dependent: :destroy
   has_many :followers, through: :follower_relationships, source: :follower
 
-  delegate :display_gender, :display_age, to: :profile, allow_nil: true
+  delegate :display_age, to: :profile, allow_nil: true
 
   def has_written?(article)
     self.articles.exists?(id: article.id)
@@ -45,6 +45,11 @@ class User < ApplicationRecord
   def display_name
     self.profile&.nickname || self.email.split("@").first
   end
+
+  def display_gender
+    self.profile&.gender || "unknown"
+  end
+
 
   def follow!(user)
     self.following_relationships.create!(following_id: user.id)

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -1,0 +1,1 @@
+= render partial: 'commons/display_profile', locals: { user: @user }

--- a/app/views/articles/show.html.haml
+++ b/app/views/articles/show.html.haml
@@ -4,7 +4,8 @@
       = image_tag @article.eye_catch
   %h1.article_title= @article.title
   .article_detail
-    = image_tag @article.user.avatar_image
+    = link_to account_path(@article.user) do
+      = image_tag @article.user.avatar_image
     %div
       %p= @article.author_name
       %p= @article.display_created_at

--- a/app/views/commons/_display_profile.html.haml
+++ b/app/views/commons/_display_profile.html.haml
@@ -9,8 +9,11 @@
         .profilePage_user_actionButton
           - if user == current_user
             = link_to 'Edit', edit_profile_path
+          - elsif current_user&.has_followed?(user)
+            = link_to 'Unfollow', account_following_path(account_id: user.id, id: current_user.following_relationships.find_by(following_id: user.id).id), data: { turbo_method: :delete }
           - else
-            = link_to 'Follow', user_followings_path(user), data: { turbo_method: :post }
+            = link_to 'Follow', account_followings_path(user), data: { turbo_method: :post }
+
       .profilePage_user_introduction
         %p= user.profile&.introduction
 

--- a/app/views/commons/_display_profile.html.haml
+++ b/app/views/commons/_display_profile.html.haml
@@ -10,7 +10,7 @@
           - if user == current_user
             = link_to 'Edit', edit_profile_path
           - else
-            = link_to 'Follow', #
+            = link_to 'Follow', user_followings_path(user), data: { turbo_method: :post }
       .profilePage_user_introduction
         %p= user.profile&.introduction
 

--- a/app/views/commons/_display_profile.html.haml
+++ b/app/views/commons/_display_profile.html.haml
@@ -1,0 +1,19 @@
+.container.profilePage
+  .profilePage_user
+    .profilePage_user_image
+      = image_tag user.avatar_image
+    .profilePage_user_basicInfo
+      .profilePage_user_name
+        .profilePage_user_displayName
+          #{user.display_name} (#{user.display_age || '?歳'}・#{i18n_gender(user)})
+        .profilePage_user_actionButton
+          - if user == current_user
+            = link_to 'Edit', edit_profile_path
+          - else
+            = link_to 'Follow', #
+      .profilePage_user_introduction
+        %p= user.profile&.introduction
+
+.container
+  - user.articles.each do |article|
+    = render partial: 'commons/articles_index', locals: { article: article }

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -1,16 +1,1 @@
-.container.profilePage
-  .profilePage_user
-    .profilePage_user_image
-      = image_tag current_user.avatar_image
-    .profilePage_user_basicInfo
-      .profilePage_user_name
-        .profilePage_user_displayName
-          #{current_user.display_name} (#{current_user.display_age}・#{i18n_gender(current_user)})
-        .profilePage_user_actionButton
-          = link_to 'Edit', edit_profile_path
-      .profilePage_user_introduction
-        %p= current_user.profile&.introduction
-
-.container
-  - current_user.articles.each do |article|
-    = render partial: 'commons/articles_index', locals: { article: article }
+= render partial: 'commons/display_profile', locals: { user: current_user }

--- a/config/locales/enum.yml
+++ b/config/locales/enum.yml
@@ -4,3 +4,4 @@ ja:
       male: '男性'
       female: '女性'
       non_binary: 'ノンバイナリー'
+      unknown: '性別未入力'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,11 +2,6 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {
     sessions: "users/sessions"
   }
-  resources :users do
-    resources :followings, only: [:index, :create, :destroy]
-  end
-
-
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
@@ -22,7 +17,9 @@ Rails.application.routes.draw do
     resource :like, only: [ :create, :destroy ]
   end
 
-  resources :accounts, only: [ :show ]
+  resources :accounts, only: [ :show ] do
+    resources :followings, only: [:index, :create, :destroy]
+  end
   resources :favorites, only: [ :index ]
   resource :profile, only: [ :show, :edit, :update ]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,10 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {
     sessions: "users/sessions"
   }
+  resources :users do
+    resources :followings, only: [:index, :create, :destroy]
+  end
+
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
@@ -19,6 +23,6 @@ Rails.application.routes.draw do
   end
 
   resources :accounts, only: [ :show ]
-  resource :profile, only: [ :show, :edit, :update ]
   resources :favorites, only: [ :index ]
+  resource :profile, only: [ :show, :edit, :update ]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   end
 
   resources :accounts, only: [ :show ] do
-    resources :followings, only: [:index, :create, :destroy]
+    resources :followings, only: [ :index, :create, :destroy ]
   end
   resources :favorites, only: [ :index ]
   resource :profile, only: [ :show, :edit, :update ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
     resource :like, only: [ :create, :destroy ]
   end
 
+  resources :accounts, only: [ :show ]
   resource :profile, only: [ :show, :edit, :update ]
   resources :favorites, only: [ :index ]
 end

--- a/db/migrate/20250223173912_create_relationships.rb
+++ b/db/migrate/20250223173912_create_relationships.rb
@@ -1,0 +1,9 @@
+class CreateRelationships < ActiveRecord::Migration[8.0]
+  def change
+    create_table :relationships do |t|
+      t.references :follower, null: false, foreign_key: { to_table: :users }
+      t.references :following, null: false, foreign_key: { to_table: :users }
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_23_173911) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_23_173912) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -89,6 +89,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_23_173911) do
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 
+  create_table "relationships", force: :cascade do |t|
+    t.bigint "follower_id", null: false
+    t.bigint "following_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["follower_id"], name: "index_relationships_on_follower_id"
+    t.index ["following_id"], name: "index_relationships_on_following_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -103,4 +112,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_23_173911) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "relationships", "users", column: "follower_id"
+  add_foreign_key "relationships", "users", column: "following_id"
 end

--- a/test/fixtures/relationships.yml
+++ b/test/fixtures/relationships.yml
@@ -1,0 +1,31 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+# == Schema Information
+#
+# Table name: relationships
+#
+#  id           :bigint           not null, primary key
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  follower_id  :bigint           not null
+#  following_id :bigint           not null
+#
+# Indexes
+#
+#  index_relationships_on_follower_id   (follower_id)
+#  index_relationships_on_following_id  (following_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (follower_id => users.id)
+#  fk_rails_...  (following_id => users.id)
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: relationships
+#
+#  id           :bigint           not null, primary key
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  follower_id  :bigint           not null
+#  following_id :bigint           not null
+#
+# Indexes
+#
+#  index_relationships_on_follower_id   (follower_id)
+#  index_relationships_on_following_id  (following_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (follower_id => users.id)
+#  fk_rails_...  (following_id => users.id)
+#
+require "test_helper"
+
+class RelationshipTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 変更の概要

* ユーザー間のフォロー機能を実装
* フォロー/アンフォローボタンの追加
* フォロー関係を管理するモデルの作成

## なぜこの変更をするのか

* ユーザー同士のつながりを作り、コミュニティを活性化するため
* 興味のあるユーザーの投稿を追いやすくするため

## 変更内容

* Relationshipモデルの作成とアソシエーションの設定
* フォロー/アンフォロー機能のルーティング追加
* プロフィールページにフォローボタンを実装
* フォロー関連のメソッドをUserモデルに追加

## 影響範囲

* ユーザープロフィールページにフォローボタンが追加
* ユーザーモデルにフォロー関連の機能が追加

## どうやるのか

1. 他のユーザーのプロフィールページにアクセス
2. 「Follow」ボタンをクリックしてフォロー
3. 「Unfollow」ボタンをクリックしてフォロー解除

## 課題

* フォロー機能の非同期処理への対応検討

## 備考

* フォロー一覧表示機能は別途作成予定