### PR TITLE
Feat/action mailer :フォロー通知メール機能の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /tmp/*
 !/log/.keep
 !/tmp/.keep
+/.git-diff-log.txt
 
 # Ignore pidfiles, but keep the directory.
 /tmp/pids/*
@@ -35,3 +36,4 @@
 
 /app/assets/builds/*
 !/app/assets/builds/.keep
+

--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,10 @@ group :development do
 
   # Use annotate
   gem "annotaterb"
+
+  # Use letter opener
+  gem "letter_opener"
+  gem "letter_opener_web"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,8 @@ GEM
       xpath (~> 3.2)
     case_transform (0.2)
       activesupport
+    childprocess (5.1.0)
+      logger (~> 1.5)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     crass (1.0.6)
@@ -227,6 +229,17 @@ GEM
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
     language_server-protocol (3.17.0.4)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     logger (1.6.5)
     loofah (2.24.0)
       crass (~> 1.0.2)
@@ -489,6 +502,8 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
+  letter_opener
+  letter_opener_web
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)

--- a/app/mailers/relationship_mailer.rb
+++ b/app/mailers/relationship_mailer.rb
@@ -1,0 +1,7 @@
+class RelationshipMailer < ApplicationMailer
+  def new_follower(user, follower)
+    @user = user
+    @follower = follower
+    mail to: user.email, subject: '【お知らせ】フォローされました'
+  end
+end

--- a/app/mailers/relationship_mailer.rb
+++ b/app/mailers/relationship_mailer.rb
@@ -2,6 +2,6 @@ class RelationshipMailer < ApplicationMailer
   def new_follower(user, follower)
     @user = user
     @follower = follower
-    mail to: user.email, subject: '【お知らせ】フォローされました'
+    mail to: user.email, subject: "【お知らせ】フォローされました"
   end
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -21,4 +21,11 @@
 class Relationship < ApplicationRecord
   belongs_to :follower, class_name: "User"
   belongs_to :following, class_name: "User"
+
+  after_create :send_email
+
+  private
+  def send_email
+    RelationshipMailer.new_follower(following, follower).deliver_now
+  end
 end

--- a/app/views/relationship_mailer/new_follower.html.haml
+++ b/app/views/relationship_mailer/new_follower.html.haml
@@ -1,0 +1,4 @@
+%p #{@user.email}さん
+%p 以下のユーザーにフォローされました。
+
+= link_to 'プロフィールを確認する', account_url(@follower)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,6 +43,10 @@ Rails.application.configure do
   # Set localhost to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
+  # Set letter opener
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
+
   devise_for :users, controllers: {
     sessions: "users/sessions"
   }


### PR DESCRIPTION
## 変更の概要

* フォロー通知メール機能の実装
* Letter Openerの設定

## なぜこの変更をするのか

* ユーザーがフォローされた際に通知を受け取れるようにするため
* ユーザーエンゲージメントの向上を図るため

## 変更内容

* フォローされた際にメール通知が送信される機能を追加
* 開発環境でのメール確認用にLetter Openerを設定
* メールテンプレートの作成

## 影響範囲

* ユーザーに影響すること: フォローされた際にメール通知が届くようになる
* メンバーに影響すること: 開発環境でメール送信をテストできるようになる
* システムに影響すること: フォロー作成時に追加の処理（メール送信）が実行される

## どうやるのか

* 新規フォロワーが発生した際に自動的にメールが送信される
* 開発環境では /letter_opener でメールの内容を確認できる

## 課題

* メール送信の非同期化について検討が必要かもしれない
* メールテンプレートのデザインをさらに改善したい

## 備考

* Letter OpenerはGemfileに追加済み
* 本番環境ではSMTPの設定が必要