### PR TITLE
Feat/create rake task: カスタムrakeタスクを作成しました

### DIFF
--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -1,0 +1,7 @@
+namespace :notification do
+  desc "利用者にメールを送付する"
+
+  task send_emails_from_admin: :environment do
+    puts '初めてのRakeタスク'
+  end
+end

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -1,8 +1,8 @@
 namespace :notification do
   desc "利用者にメールを送付する"
 
-  task :send_emails_from_admin, ['msg'] => :environment do |task, args|
-    msg = args['msg']
+  task :send_emails_from_admin, [ "msg" ] => :environment do |task, args|
+    msg = args["msg"]
     if msg.present?
       NotificationFromAdminJob.perform_later(msg)
     else

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -1,7 +1,12 @@
 namespace :notification do
   desc "利用者にメールを送付する"
 
-  task send_emails_from_admin: :environment do
-    puts '初めてのRakeタスク'
+  task :send_emails_from_admin, ['msg'] => :environment do |task, args|
+    msg = args['msg']
+    if msg.present?
+      NotificationFromAdminJob.perform_later(msg)
+    else
+      puts "送信できませんでした"
+    end
   end
 end


### PR DESCRIPTION
## 変更の概要

* 管理者からユーザーにメール通知を送信するためのRakeタスクを追加
* Rubocopを適用してコードスタイルを修正

## なぜこの変更をするのか

* 管理者がコマンドラインから簡単にユーザー全体にメール通知を送れるようにするため
* メンテナンス性を高めるためにコードスタイルを統一

## 変更内容

* `notification` namespaceに `send_emails_from_admin` Rakeタスクを追加
  * 引数としてメッセージを受け取り、`NotificationFromAdminJob`を実行
* Rubocopによるコードスタイルの修正
  * シングルクォートからダブルクォートへの変更
  * 配列の表記方法の統一（スペースの追加）

## 影響範囲

* システムに影響すること：
  * 新しいRakeタスクにより、管理者は簡単にすべてのユーザーにメール通知を送信可能になる
  * バックグラウンドジョブを利用することで、大量のメール送信時もシステムパフォーマンスへの影響を最小化

## どうやるのか

* 使い方：
  ```
  rake notification:send_emails_from_admin["通知したいメッセージ"]
  ```
* メッセージが空の場合は「送信できませんでした」と表示される

## 課題

* メール送信の成功/失敗の詳細なログ出力が今後必要かもしれない
* 特定のユーザーグループにのみメールを送る機能の拡張を検討中

## 備考

* 本機能はテスト環境での検証済み
* 将来的に管理画面からも同様の機能を提供予定
